### PR TITLE
Color Plugin

### DIFF
--- a/generators/css-in-js/package.json
+++ b/generators/css-in-js/package.json
@@ -14,8 +14,8 @@
     "test": "cross-env BABEL_ENV=commonjs jest",
     "coverage": "yarn test --coverage"
   },
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "dependencies": {
     "@elodin/runtime": "^0.0.22",

--- a/generators/react-native/package.json
+++ b/generators/react-native/package.json
@@ -14,8 +14,8 @@
     "test": "cross-env BABEL_ENV=commonjs jest",
     "coverage": "yarn test --coverage"
   },
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "dependencies": {
     "@elodin/utils": "^0.0.22",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
   "name": "elodin",
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "scripts": {
     "bootstrap": "lerna bootstrap --reject-cycles",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,8 +14,8 @@
     "test": "echo 1",
     "coverage": "yarn test --coverage"
   },
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "bin": {
     "elodin": "./bin/elodin.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,8 +14,8 @@
     "test": "echo 1",
     "coverage": "yarn test --coverage"
   },
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "dependencies": {
     "@elodin/parser": "^0.0.22",

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -14,8 +14,8 @@
     "test": "cross-env BABEL_ENV=commonjs jest",
     "coverage": "yarn test --coverage"
   },
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "dependencies": {
     "@elodin/parser": "^0.0.22",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -14,8 +14,8 @@
     "test": "cross-env BABEL_ENV=commonjs jest",
     "coverage": "yarn test --coverage"
   },
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "dependencies": {
     "color": "^3.1.2",

--- a/packages/prettier-plugin-elodin/package.json
+++ b/packages/prettier-plugin-elodin/package.json
@@ -20,8 +20,8 @@
     "prettier",
     "prettier-plugin"
   ],
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "dependencies": {
     "@elodin/format": "^0.0.22"

--- a/packages/stdlib/package.json
+++ b/packages/stdlib/package.json
@@ -14,8 +14,8 @@
     "test": "cross-env BABEL_ENV=commonjs jest",
     "coverage": "yarn test --coverage"
   },
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "dependencies": {
     "color": "^3.1.0"

--- a/packages/traverser/package.json
+++ b/packages/traverser/package.json
@@ -14,8 +14,8 @@
     "test": "cross-env BABEL_ENV=commonjs jest",
     "coverage": "yarn test --coverage"
   },
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "dependencies": {
     "@elodin/parser": "^0.0.22",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,8 +14,8 @@
     "test": "cross-env BABEL_ENV=commonjs jest",
     "coverage": "yarn test --coverage"
   },
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "devDependencies": {
     "@babel/cli": "^7.2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,8 +14,8 @@
     "test": "cross-env BABEL_ENV=commonjs jest",
     "coverage": "yarn test --coverage"
   },
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "peerDependencies": {
     "@elodin/core": "^0.0.16"

--- a/plugins/color/.babelrc
+++ b/plugins/color/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "@babel/preset-env"
+  ]
+}

--- a/plugins/color/package.json
+++ b/plugins/color/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@elodin/generator-reason",
+  "name": "@elodin/plugin-color",
   "version": "0.0.22",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -17,14 +17,11 @@
   "repository": "https://github.com/robinweser/elodin.git",
   "author": "robinweser <contact@weser.io>",
   "license": "MIT",
-  "dependencies": {
-    "@elodin/utils": "^0.0.22",
-    "css-in-js-utils": "^3.0.0"
-  },
   "devDependencies": {
     "@babel/cli": "^7.2.0",
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.0",
+    "@elodin/core": "^0.0.22",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "cross-env": "^5.2.0",

--- a/plugins/color/src/__tests__/__snapshots__/index-test.js.snap
+++ b/plugins/color/src/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Replacing variables should correctly replace variables 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "body": Array [
+        Object {
+          "dynamic": false,
+          "property": "backgroundColor",
+          "raw": false,
+          "type": "Declaration",
+          "value": Object {
+            "alpha": 1,
+            "blue": 0,
+            "format": "hex",
+            "green": 0,
+            "red": 255,
+            "type": "Color",
+          },
+        },
+        Object {
+          "dynamic": false,
+          "property": "borderBottomColor",
+          "raw": false,
+          "type": "Declaration",
+          "value": Object {
+            "alpha": 1,
+            "blue": 50,
+            "format": "hex",
+            "green": 100,
+            "red": 255,
+            "type": "Color",
+          },
+        },
+      ],
+      "format": "view",
+      "name": "Button",
+      "type": "Style",
+    },
+  ],
+  "type": "File",
+}
+`;
+
+exports[`Replacing variables should work with custom selectors 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "body": Array [
+        Object {
+          "dynamic": false,
+          "property": "paddingLeft",
+          "raw": false,
+          "type": "Declaration",
+          "value": Object {
+            "negative": false,
+            "type": "Integer",
+            "value": 10,
+          },
+        },
+        Object {
+          "dynamic": false,
+          "property": "backgroundColor",
+          "raw": false,
+          "type": "Declaration",
+          "value": Object {
+            "type": "Identifier",
+            "value": "red",
+          },
+        },
+      ],
+      "format": "view",
+      "name": "Button",
+      "type": "Style",
+    },
+  ],
+  "type": "File",
+}
+`;

--- a/plugins/color/src/__tests__/index-test.js
+++ b/plugins/color/src/__tests__/index-test.js
@@ -1,0 +1,13 @@
+import { traverse, parse } from '@elodin/core'
+
+import color from '../index'
+
+describe('Replacing variables', () => {
+  it('should correctly replace variables', () => {
+    const file = `view Button { backgroundColor: red borderBottomColor: rgb(255 100 50) }`
+
+    const ast = parse(file).ast
+
+    expect(traverse(ast, [color('hex')])).toMatchSnapshot()
+  })
+})

--- a/plugins/color/src/index.js
+++ b/plugins/color/src/index.js
@@ -1,0 +1,12 @@
+const defaultSelector = (variables, property) => variables[property]
+
+// available formats: rgb, hsl, hex, keyword
+export default function color(format = 'rgb') {
+  return {
+    Color: {
+      enter(path) {
+        path.node.format = format
+      },
+    },
+  }
+}

--- a/plugins/replace-variable/package.json
+++ b/plugins/replace-variable/package.json
@@ -14,8 +14,8 @@
     "test": "cross-env BABEL_ENV=commonjs jest",
     "coverage": "yarn test --coverage"
   },
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "devDependencies": {
     "@babel/cli": "^7.2.0",

--- a/runtimes/javascript/package.json
+++ b/runtimes/javascript/package.json
@@ -14,8 +14,8 @@
     "test": "echo 1",
     "coverage": "yarn test --coverage"
   },
-  "repository": "https://github.com/rofrischmann/elodin.git",
-  "author": "rofrischmann <robin@rofrischmann.de>",
+  "repository": "https://github.com/robinweser/elodin.git",
+  "author": "robinweser <contact@weser.io>",
   "license": "MIT",
   "devDependencies": {
     "@babel/cli": "^7.2.0",


### PR DESCRIPTION
## Description

This PR adds a basic color plugin that normalises the color format of all colors to a single format.


## Example

<!------------------------------------------
If possible, add a code example or a link to a working example/repository.
------------------------------------------->

```javascript
import { transformFile } from '@elodin/core'
import color from '@elodin/plugin-color'

const config = {
  plugins: [
    color("rgb")
  ]
}

transformFile(FILE_PATH, config)
```

## Versioning

<!------------------------------------------
Please add a suggested version bump.
If there's no change to the actual code, just remove this section.

Major = Breaking API change (not backwards-compatible)
Minor = Added Functionality
Patch = Bug Fixes
------------------------------------------->

Minor

## Checklist

#### Quality Assurance

<!------------------------------------------
Make sure that `npm run check` runs without failing or the CI will fail as well.
If a check doesn't make sense due to the nature of the PR, just check it anyways.
------------------------------------------->

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] The CHANGELOG.md has been updated
